### PR TITLE
Update github output syntax

### DIFF
--- a/determine_current_pr_labels.sh
+++ b/determine_current_pr_labels.sh
@@ -33,4 +33,4 @@ fi
 # Now that we've determined whether the PR is already labeled, let's export that information
 echo "Label present: $LABEL_PRESENT"
 echo ""
-echo "::set-output name=label_present::${LABEL_PRESENT}"
+echo "label_present=${LABEL_PRESENT}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## what
Update github output syntax

## why
Following github docs

## references
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/