### PR TITLE
Update github output syntax

### DIFF
--- a/identify_required_pr_labels.sh
+++ b/identify_required_pr_labels.sh
@@ -81,4 +81,4 @@ done
 # Now that we've determined the desired value of LABEL_NEEDED, let's export it for use in labeling the pull request.
 echo "Label needed: $LABEL_NEEDED"
 echo ""
-echo "::set-output name=label_needed::${LABEL_NEEDED}"
+echo "label_needed=${LABEL_NEEDED}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## what
Update github output syntax

## why
Following github docs

## references
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/